### PR TITLE
fix: remove COPY nginx config command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ ENV NODE_ENV production
 
 COPY --from=builder /app/build/ .
 
-COPY default.conf /etc/nginx/conf.d/
-
 ENV PORT=80
 
 ENTRYPOINT ["/http-server"]


### PR DESCRIPTION
## Description
Remove a line that copies nginx config. We no longer used Nginx and this slipped in previous PR.

## Related Issue(s)
None

## How to test
